### PR TITLE
fix: add settlement timeout and emergency refund for stuck directional positions

### DIFF
--- a/contracts/EventBasedPredictionMarket.sol
+++ b/contracts/EventBasedPredictionMarket.sol
@@ -22,6 +22,9 @@ import "@uma/core/contracts/data-verification-mechanism/interfaces/IdentifierWhi
  *   4. Anyone can propose a resolution price via the OO. After the liveness period, the market settles.
  *   5. If disputed, the OO escalates to UMA's DVM for arbitration and re-requests the price.
  *   6. Once settled, users call settle() to redeem tokens for collateral based on the outcome.
+ *   7. If nobody proposes/resolves a price within SETTLEMENT_TIMEOUT of initialization, any token
+ *      holder can call emergencyRefund() to redeem at a neutral 0.5/0.5 split instead of waiting
+ *      indefinitely on the Optimistic Oracle.
  *
  * Resolution values:
  *   - 1e18 (YES): Long tokens worth 1 collateral each, Short tokens worth 0.
@@ -49,6 +52,10 @@ contract EventBasedPredictionMarket is Testable {
     // Price returned from the Optimistic Oracle at settlement time.
     int256 public expiryPrice;
 
+    // Timestamp after which emergencyRefund() becomes callable if the OO still hasn't settled a price.
+    uint256 public settlementDeadline;
+    uint256 public constant SETTLEMENT_TIMEOUT = 72 hours;
+
     // External contract interfaces.
     ExpandedERC20 public collateralToken;
     ExpandedIERC20 public longToken;
@@ -70,6 +77,7 @@ contract EventBasedPredictionMarket is Testable {
     event PositionSettled(address indexed sponsor, uint256 collateralReturned, uint256 longTokens, uint256 shortTokens);
     event MarketInitialized(uint256 requestTimestamp);
     event PriceDisputed(uint256 oldTimestamp, uint256 newTimestamp);
+    event EmergencyRefund(address indexed sponsor, uint256 collateralReturned, uint256 longTokens, uint256 shortTokens);
 
     /****************************************
      *               MODIFIERS              *
@@ -136,6 +144,7 @@ contract EventBasedPredictionMarket is Testable {
         }
 
         _requestOraclePrice();
+        settlementDeadline = getCurrentTime() + SETTLEMENT_TIMEOUT;
 
         emit MarketInitialized(requestTimestamp);
     }
@@ -199,6 +208,9 @@ contract EventBasedPredictionMarket is Testable {
         requestTimestamp = getCurrentTime();
         _requestOraclePrice();
 
+        // NOTE: settlementDeadline intentionally does NOT reset here. A dispute that occurs close to
+        // the deadline can race emergencyRefund() against a legitimate re-resolution — see PR discussion.
+
         emit PriceDisputed(oldTimestamp, requestTimestamp);
     }
 
@@ -250,6 +262,34 @@ contract EventBasedPredictionMarket is Testable {
         collateralToken.safeTransfer(msg.sender, collateralReturned);
 
         emit PositionSettled(msg.sender, collateralReturned, longTokensToRedeem, shortTokensToRedeem);
+    }
+
+    /**
+     * @notice Emergency exit for token holders when the Optimistic Oracle never resolves a price.
+     * Callable only after SETTLEMENT_TIMEOUT has elapsed since initializeMarket() with no settlement
+     * price received. Pays out at a neutral 0.5/0.5 split (same math as an "Undetermined" OO result),
+     * since the true outcome was never established. Directional (one-sided) holders are otherwise
+     * unable to exit — redeem() only works for matched Long+Short pairs.
+     * @param longTokensToRedeem Number of Long tokens to redeem.
+     * @param shortTokensToRedeem Number of Short tokens to redeem.
+     * @return collateralReturned Total collateral returned.
+     */
+    function emergencyRefund(
+        uint256 longTokensToRedeem,
+        uint256 shortTokensToRedeem
+    ) public requestInitialized returns (uint256 collateralReturned) {
+        require(getCurrentTime() > settlementDeadline, "Settlement deadline not reached");
+        require(!receivedSettlementPrice, "Price already resolved, use settle()");
+
+        require(longToken.burnFrom(msg.sender, longTokensToRedeem));
+        require(shortToken.burnFrom(msg.sender, shortTokensToRedeem));
+
+        // Undetermined-equivalent split: every token (long or short) is worth exactly 0.5 collateral,
+        // since no outcome was ever established.
+        collateralReturned = ((longTokensToRedeem + shortTokensToRedeem) * 5e17) / 1e18;
+        collateralToken.safeTransfer(msg.sender, collateralReturned);
+
+        emit EmergencyRefund(msg.sender, collateralReturned, longTokensToRedeem, shortTokensToRedeem);
     }
 
     /****************************************


### PR DESCRIPTION
## Problem

`EventBasedPredictionMarket` resolves via UMA's Optimistic Oracle V2, which is a real
improvement over a single-admin-key oracle — anyone can permissionlessly call
`proposePrice()`, and disputes escalate to the DVM. That part works well.

However, there's no fallback if **nobody ever proposes a price** (e.g. a low-interest
market where the `proposerReward` doesn't attract a proposer, or the underlying question
becomes unresolvable). In that case:

- `receivedSettlementPrice` stays `false` forever.
- `settle()` reverts indefinitely (`require(receivedSettlementPrice, ...)`).
- `redeem()` only works for holders of **matched** Long+Short pairs (1:1 burn). Anyone
  holding a one-sided directional position — which is the normal outcome of trading
  through the AMM — has no exit path at all.

I ran into this while building a live weather prediction market on Arc Testnet
(~55 Arc Testnet transactions across create/lock/settle/claim flows) using a simpler
`onlyOracle`-gated design, and traced the same failure mode back to this reference
implementation while evaluating a migration to it.

## Fix

- Adds `settlementDeadline`, set to `block timestamp of initializeMarket() + SETTLEMENT_TIMEOUT`
  (`72 hours`, currently a fixed constant — open to making this configurable per-market).
- Adds `emergencyRefund(longTokensToRedeem, shortTokensToRedeem)`: callable by any token
  holder once `settlementDeadline` has passed with no settlement price received. Pays out
  at a neutral 0.5/0.5 split per token — the same math the contract already uses for the
  OO's "Undetermined" (`5e17`) outcome — since the true result was never established.

## Known limitation / open question for maintainers

`priceDisputed()` re-requests a price with a fresh timestamp but does **not** reset
`settlementDeadline`. If a dispute lands close to the original deadline, `emergencyRefund()`
could theoretically become callable while a legitimate DVM arbitration is still in flight.
I left this as-is and flagged it with a code comment rather than guessing at the right
behavior (extend the deadline on every dispute? cap the number of extensions?) — wanted to
raise it for discussion rather than bake in an assumption.

Also not included yet: unit tests for the new function and the timeout boundary. Happy to
add a test file (mirroring the existing Hardhat/UMA test setup) if the general approach
looks right to maintainers before I invest in test scaffolding.

## Testing

Not yet covered by automated tests — see note above. Manually reasoned through the
solvency invariant: before any settlement, `longToken.totalSupply() == shortToken.totalSupply()
== collateralToken.balanceOf(address(this))` (since `create()`/`redeem()` always move both
sides in lockstep), so the 0.5/0.5 split in `emergencyRefund()` can't be under-collateralized
in the no-dispute case.