### PR TITLE
docs: fix Node version requirement and misleading RPC URL placeholder in Getting Started

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,9 @@
 # Deployer wallet private key (for contract deployment)
 PRIVATE_KEY=your_private_key_here
 
-# Alchemy RPC URL (used by both Hardhat and the frontend)
-NEXT_PUBLIC_ALCHEMY_RPC_URL=https://your-alchemy-rpc-url-here
+# Alchemy RPC URL (used by both Hardhat and the frontend). Optional - falls back to
+# the public Arc Testnet RPC (https://rpc.testnet.arc.network) if left unset.
+# NEXT_PUBLIC_ALCHEMY_RPC_URL=https://your-alchemy-rpc-url-here
 
 # Circle modular wallets (required for passkey wallet support)
 NEXT_PUBLIC_CIRCLE_CLIENT_KEY=your_circle_client_key_here

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Since UMA's oracle infrastructure is not natively deployed on Arc Testnet, the d
 
 ## Prerequisites
 
-- **Node.js v18+** - Install via [nvm](https://github.com/nvm-sh/nvm)
+- **Node.js v20.9+** - Install via [nvm](https://github.com/nvm-sh/nvm) (required by Next.js 16)
 - **A wallet** - either:
   - **MetaMask** (or any injected EVM wallet) - connected to **Arc Testnet** (Chain ID `5042002`), or
   - **Circle Passkey Wallet** - browser-based biometric authentication via WebAuthn (no extension needed). Requires a [Circle developer account](https://console.circle.com/) for the client key and URL.
@@ -59,7 +59,7 @@ Since UMA's oracle infrastructure is not natively deployed on Arc Testnet, the d
    cp .env.example .env.local
    ```
 
-   Edit `.env.local` and fill in your deployer private key and (optionally) Circle credentials (see [Environment Variables](#environment-variables)). The Arc Testnet RPC URL is pre-filled.
+   Edit `.env.local` and fill in your deployer private key and (optionally) Circle credentials (see [Environment Variables](#environment-variables)). `NEXT_PUBLIC_ALCHEMY_RPC_URL` is optional - leave it unset to use the public Arc Testnet RPC, or set your own Alchemy URL for better reliability.
 
    > **Note:** Deployment requires a **non-custodial wallet** (e.g. MetaMask) whose private key you can export. Custodial wallets like Circle passkey wallets do not expose private keys and cannot be used for deployment. The Circle wallet integration is for end users interacting with the deployed contracts via the frontend.
 


### PR DESCRIPTION
## Summary
Discovered while following the Getting Started guide to deploy my own prediction market on Arc.

Two inaccuracies in the Getting Started flow that will break onboarding for anyone
following the README literally:

**1. Node.js version requirement is wrong**

README Prerequisites says "Node.js v18+", but `package.json` pins `"next": "16.2.0"`.
Next.js 16.2.0's own published `package.json` declares `"engines": {"node": ">=20.9.0"}`
(verified against `https://registry.npmjs.org/next/16.2.0`). A developer on Node 18/19
following the README will hit an unsupported-engine error or undefined behavior at
`npm install` / `npm run dev`.

**2. RPC URL is not actually "pre-filled" — it's a broken placeholder**

README step 2 says: "The Arc Testnet RPC URL is pre-filled." In reality, `.env.example`
sets `NEXT_PUBLIC_ALCHEMY_RPC_URL=https://your-alchemy-rpc-url-here` as an *active,
uncommented* value. Both `hardhat.config.ts:45` and `lib/chain.ts:21-22` use:

```ts
process.env.NEXT_PUBLIC_ALCHEMY_RPC_URL || "https://rpc.testnet.arc.network"

A non-empty placeholder string defeats that fallback. A developer who copies
.env.example → .env.local and only fills in PRIVATE_KEY (as the README instructs)
ends up with npm run deploy and the frontend's RPC calls pointed at the literal bogus
host your-alchemy-rpc-url-here, breaking the guided deploy flow on first run.

Changes

- README.md: correct the Node version requirement to v20.9+ (with a note that it's
required by Next.js 16), and reword the RPC URL description to explain it's optional
and what happens if left unset.
- .env.example: comment out NEXT_PUBLIC_ALCHEMY_RPC_URL's placeholder value (same
pattern already used for the auto-written contract address vars further down in the
same file), so the code's existing fallback to the public Arc Testnet RPC actually
takes effect when a developer doesn't have an Alchemy key yet.

No application code changed — only documentation and the environment template.

Test plan

- [ ] cp .env.example .env.local, fill in only PRIVATE_KEY, run npm run deploy —
confirm it connects to https://rpc.testnet.arc.network instead of failing on
the placeholder host
- [ ] Confirm npm install / npm run dev behave as expected on Node 20.9+