### PR TITLE
fix(deploy): refuse MockOracleAncillary wiring outside Arc Testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Resolution is handled by UMA's Optimistic Oracle V2: anyone can propose an outco
 
 Since UMA's oracle infrastructure is not natively deployed on Arc Testnet, the deploy script bootstraps the entire UMA ecosystem on-chain - Finder, IdentifierWhitelist, AddressWhitelist, Store, MockOracleAncillary, and OptimisticOracleV2.
 
+> **Testnet-only oracle wiring:** `MockOracleAncillary` is a permissionless UMA test double (`pushPrice` has no access control). The deploy script refuses to run on any chain other than Arc Testnet (`5042002`) so this mock cannot be copied into a valued network as the Finder `Oracle` implementation. A production deployment needs a real dispute-resolution backend (UMA's DVM is not deployed on Arc today).
+
 <img alt="Arc Nanopayments Demo dashboard" src="public/screenshot.png" />
 
 ## Table of Contents

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -67,6 +67,10 @@ const CONFIG = {
   deployerMint: ethers.parseEther("100000"),  // 100,000 ARCT for deployer
 };
 
+/** Arc Testnet chain ID. MockOracleAncillary is intentionally permissionless and
+ *  must only be registered as Finder "Oracle" on this network. */
+const ARC_TESTNET_CHAIN_ID = 5042002n;
+
 // --- Helpers --------------------------------------------------------
 
 async function deployFromArtifact(
@@ -156,6 +160,17 @@ async function main() {
   const balance = await ethers.provider.getBalance(baseSigner.address);
 
   console.log("=== UMA Prediction Market Deployment ===\n");
+
+  const network = await ethers.provider.getNetwork();
+  console.log("Network:", network.name || "(unnamed)", `chainId=${network.chainId}`);
+  if (network.chainId !== ARC_TESTNET_CHAIN_ID) {
+    throw new Error(
+      `Refusing to deploy MockOracleAncillary outside Arc Testnet. ` +
+        `This script registers a permissionless mock DVM as Finder "Oracle", which is only safe on Arc Testnet ` +
+        `(chainId ${ARC_TESTNET_CHAIN_ID}). Current chainId=${network.chainId}.`
+    );
+  }
+
   console.log("Deployer:", baseSigner.address);
   console.log("Balance:", ethers.formatUnits(balance, 18), "(native gas)\n");
 


### PR DESCRIPTION
## Summary
Fixes #21.

`scripts/deploy.ts` deploys UMA's permissionless `MockOracleAncillary` and registers it in the Finder as `"Oracle"`. That is correct for Arc Testnet sandboxes, but this repo is a reference template — cloning the script onto a valued network would leave dispute resolution as an open `pushPrice()` anyone can call.

## Changes
1. **Chain-ID guard** — refuse to run the deploy script unless `provider.getNetwork().chainId === 5042002` (Arc Testnet), with an error that names this risk.
2. **Deploy summary** — print which address the Finder resolves for `"Oracle"` so auditors see the mock immediately.
3. **README** — document that the mock-DVM wiring is testnet-only and that UMA's real DVM is not deployed on Arc today.

## Notes
Hardhat currently only defines the `arcTestnet` network, so nothing ships the mock to a valued network today. The guard is still useful so the template cannot be reused elsewhere without an explicit, loud failure.